### PR TITLE
Fixes bug in repo name

### DIFF
--- a/rules/aeryn.ts
+++ b/rules/aeryn.ts
@@ -11,7 +11,7 @@ const wrap: any = isJest ? _test : _run
 
 export const aeryn = wrap("When a PR is merged, check if the author is in the org", async () => {
   const pr = danger.github.pr
-  const repo = danger.github.pr.head.repo.name
+  const repo = danger.github.pr.base.repo.name
   const owner = "ashfurrow"
   const username = pr.user.login
   const api = danger.github.api

--- a/tests/aeryn.test.ts
+++ b/tests/aeryn.test.ts
@@ -12,7 +12,7 @@ beforeEach(() => {
         user: {
           login: "a_new_user",
         },
-        head: {
+        base: {
           repo: {
             name: "some_repo",
           },


### PR DESCRIPTION
Fixes #5. Come to think of it, this was kind of a security concern since someone could fork a repo that has this Dangerfile run against it, then modify their fork name to maliciously get auto-invited to any repo of mine, like my blog for example. Yikes! /cc @orta. Thanks to @thii for the help debugging.